### PR TITLE
Various improvements and features

### DIFF
--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -92,6 +92,13 @@ class HashDiffer(TableDiffer):
             # Update schemas to minimal mutual precision
             col1 = table1._schema[c1]
             col2 = table2._schema[c2]
+
+            # if user passed specialized conversions for either column, skip validation
+            if any(c in table1.col_conversions for c in [c1.lower(), c1.upper()]):
+                continue
+            if any(c in table2.col_conversions for c in [c2.lower(), c2.upper()]):
+                continue
+
             if isinstance(col1, PrecisionType):
                 if not isinstance(col2, PrecisionType):
                     raise TypeError(f"Incompatible types for column '{c1}':  {col1} <-> {col2}")

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -80,6 +80,8 @@ class HashDiffer(TableDiffer):
         if self.bisection_factor < 2:
             raise ValueError("Must have at least two segments per iteration (i.e. bisection_factor >= 2)")
 
+        super().__post_init__()
+        
     def _validate_and_adjust_columns(self, table1, table2):
         for c1, c2 in safezip(table1.relevant_columns, table2.relevant_columns):
             if c1 not in table1._schema:
@@ -410,8 +412,8 @@ class GroupingHashDiffer(HashDiffer):
             f"size: table1 <= {table1.approximate_size()}, table2 <= {table2.approximate_size()}"
         )
 
-        ti = ThreadedYielder(self.max_threadpool_size)
+        self.ti = ThreadedYielder(self.max_threadpool_size)
         # Bisect (split) the table into segments, and diff them recursively.
-        ti.submit(self._bisect_and_diff_segments, ti, table1, table2, info_tree)
+        self.ti.submit(self._bisect_and_diff_segments, self.ti, table1, table2, info_tree)
 
-        return ti
+        return self.ti

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -186,6 +186,10 @@ class HashDiffer(TableDiffer):
             info_tree.info.is_diff = False
             return
 
+        logging.info(f'Mismatch checksum {table1.min_key} - {table2.max_key}\n'
+                     f'T1: cs={checksum1}, count={count1}\n'
+                     f'T2: cs={checksum2}, count={count2}')
+
         info_tree.info.is_diff = True
         return self._bisect_and_diff_segments(ti, table1, table2, info_tree, level=level, max_rows=max(count1, count2))
 
@@ -209,6 +213,8 @@ class HashDiffer(TableDiffer):
         # If count is below the threshold, just download and compare the columns locally
         # This saves time, as bisection speed is limited by ping and query performance.
         if max_rows < self.bisection_threshold or max_space_size < self.bisection_factor * 2:
+            logging.info(f'Downloading rows from T1 {table1.min_key} - {table1.max_key}')
+            logging.info(f'Downloading rows from T2 {table2.min_key} - {table2.max_key}')
             rows1, rows2 = self._threaded_call("get_values", [table1, table2])
             diff = list(diff_sets(rows1, rows2, table1.key_indices))
 
@@ -259,6 +265,10 @@ class GroupingHashDiffer(HashDiffer):
         if checksum1 == checksum2:
             info_tree.info.is_diff = False
             return
+
+        logging.info(f'Mismatch checksum {segment1.min_key} - {segment1.max_key}\n'
+                     f'T1: cs={checksum1}, count={count1}\n'
+                     f'T2: cs={checksum2}, count={count2}')
 
         info_tree.info.is_diff = True
         return self._bisect_and_diff_segments(ti, segment1, segment2, info_tree, level=level, max_rows=max(count1, count2))

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -94,9 +94,11 @@ class HashDiffer(TableDiffer):
             col2 = table2._schema[c2]
 
             # if user passed specialized conversions for either column, skip validation
-            if any(c in table1.col_conversions for c in [c1.lower(), c1.upper()]):
+            t1_overrides = {**table1.col_conversions, **table1.column_type_overrides}
+            t2_overrides = {**table2.col_conversions, **table2.column_type_overrides}
+            if any(c in t1_overrides for c in [c1.lower(), c1.upper()]):
                 continue
-            if any(c in table2.col_conversions for c in [c2.lower(), c2.upper()]):
+            if any(c in t2_overrides for c in [c2.lower(), c2.upper()]):
                 continue
 
             if isinstance(col1, PrecisionType):

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -32,9 +32,6 @@ def diff_sets(a: set, b: set, key_indices: list = None) -> Iterator:
     if key_indices == None:
         key_indices = [0]
 
-    # The first item of key_indices should always be the first key_column (see TableDiffer.relevant_columns)
-    assert key_indices[0] == 0
-
     # NOTE: updated to support sorting on multiple PK columns (compound keys)
     d = defaultdict(list)
     for row in a:

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -1,7 +1,7 @@
 from dataclasses import field
 import math
 import time
-from typing import List, Tuple
+from typing import Any, List, Optional, Tuple, Union
 import logging
 from itertools import product
 
@@ -13,10 +13,31 @@ from sqeleton.databases import Database, DbPath, DbKey, DbTime
 from sqeleton.schema import Schema, create_schema
 from sqeleton.queries import Count, Checksum, SKIP, table, this, Expr, min_, max_, Code, Compiler
 from sqeleton.queries.extras import ApplyFuncAndNormalizeAsString, NormalizeAsString
+from sqeleton.abcs import database_types as DB_TYPES
 
 logger = logging.getLogger("table_segment")
 
 RECOMMENDED_CHECKSUM_DURATION = 20
+
+COL_TYPE_OVERRIDE_MAP = {
+    'String_VaryingAlphanum': DB_TYPES.String_VaryingAlphanum,
+    'String_FixedAlphanum': DB_TYPES.String_FixedAlphanum,
+    'Integer': DB_TYPES.Integer,
+    'Decimal': DB_TYPES.Decimal,
+}
+
+
+def get_database_type(type_info: Union[str, tuple]) -> Any:
+    type_str = type_info
+    if type(type_info) == tuple:
+        type_str = type_info[0]
+
+    cls = COL_TYPE_OVERRIDE_MAP[type_str]
+    
+    if type_str == 'Decimal':
+        return cls(type_info[1])
+
+    return cls()
 
 
 def split_key_space(min_key: DbKey, max_key: DbKey, count: int) -> List[DbKey]:
@@ -139,10 +160,10 @@ class TableSegment:
     true_key_indices: list = None
 
     # use to force cast certain columns to non-standard types 
-    column_type_overrides: List[Tuple] = None
+    column_type_overrides: dict[str, Tuple] = field(default_factory=dict)
 
     # use to cast/convert certain columns to non-standard types 
-    col_conversions: dict[str, str] = field(default_factory=dict)
+    col_conversions: dict[str, dict] = field(default_factory=dict)
 
     case_sensitive: bool = True
     _schema: Schema = None
@@ -163,14 +184,13 @@ class TableSegment:
         return f"({self.where})" if self.where else None
 
     def _with_raw_schema(self, raw_schema: dict) -> "TableSegment":
-        if self.column_type_overrides is not None:
-            for col_info in self.column_type_overrides:
-                col_name = col_info[0]
-                if col_name not in raw_schema:
-                    raise ValueError(f'Column {col_name} not found in schema for DB {self.database}')
-                raw_schema[col_name] = col_info
-
         schema = self.database._process_table_schema(self.table_path, raw_schema, self.relevant_columns, self._where())
+
+        if self.column_type_overrides is not None:
+            for col, col_info in self.column_type_overrides.items():
+                if all(c not in raw_schema for c in [col.lower(), col.upper()]):
+                    raise ValueError(f'Column {col} not found in schema for DB {self.database}')
+                schema[col] = get_database_type(col_info)
 
         return self.new(_schema=create_schema(self.database, self.table_path, schema, self.case_sensitive))
 
@@ -187,10 +207,18 @@ class TableSegment:
     def _make_key_range(self):
         if self.min_key is not None:
             for mn, k in safezip(self.min_key, self.key_columns):
-                yield mn <= this[k]
+                converted_col, _ = self.col_conversion(k)
+                if converted_col:
+                    yield Code(f"{converted_col} >= '{mn}'")
+                else:
+                    yield mn <= this[k]
         if self.max_key is not None:
             for k, mx in safezip(self.key_columns, self.max_key):
-                yield this[k] < mx
+                converted_col, _ = self.col_conversion(k)
+                if converted_col:
+                    yield Code(f"{converted_col} < '{mx}'")
+                else:
+                    yield this[k] < mx
 
     def _make_update_range(self):
         if self.min_update is not None:
@@ -202,14 +230,20 @@ class TableSegment:
     def source_table(self):
         return table(*self.table_path, schema=self._schema)
 
-    def make_select(self):
-        return self.source_table.where(
-            *self._make_key_range(), *self._make_update_range(), Code(self._where()) if self.where else SKIP
-        )
+    def make_select(self, incl_update_range=True):
+        if incl_update_range:
+            return self.source_table.where(
+                *self._make_key_range(), *self._make_update_range(), Code(self._where()) if self.where else SKIP
+            )
+        else:
+            return self.source_table.where(
+                *self._make_key_range(), Code(self._where()) if self.where else SKIP
+            )
 
     def get_values(self) -> list:
         "Download all the relevant values of the segment from the database"
-        select = self.make_select().select(*self._relevant_columns_repr)
+        select = self.make_select(incl_update_range=False).select(
+            *self._relevant_columns_repr('select_values'))
         return self.database.query(select, List[Tuple])
 
     def choose_checkpoints(self, count: int) -> List[DbKey]:
@@ -246,19 +280,26 @@ class TableSegment:
     def relevant_columns(self) -> List[str]:
         extras = list(self.extra_columns)
 
-        if self.update_column and self.update_column not in extras:
+        if self.update_column and self.update_column not in extras \
+            and self.update_column not in list(self.key_columns):
             extras = [self.update_column] + extras
 
         return list(self.key_columns) + extras
-
-    @property
-    def _relevant_columns_repr(self) -> List[Expr]:
+    
+    def col_conversion(self, c: str) -> tuple[Optional[str], Optional[list]]:
+        conversion_info = self.col_conversions.get(c.lower(), self.col_conversions.get(c.upper()))
+        if conversion_info:
+            placeholders = conversion_info['template'].count('{}')
+            return conversion_info['template'].format(*([c]*placeholders)), conversion_info.get('exclude_from', [])
+        else:
+            return None, None
+        
+    def _relevant_columns_repr(self, usage: str) -> List[Expr]:
         normalized_cols = []
         for c in self.relevant_columns:
-            conversion = self.col_conversions.get(c.lower(), self.col_conversions.get(c.upper()))
-            if conversion:
-                placeholders = conversion.count('{}')
-                normalized_cols.append(Code(conversion.format(*([c]*placeholders))))
+            converted_col, exclude_from = self.col_conversion(c)
+            if converted_col and usage not in exclude_from:
+                normalized_cols.append(Code(converted_col))
             else:
                 normalized_cols.append(NormalizeAsString(this[c]))
 
@@ -277,7 +318,7 @@ class TableSegment:
 
         start = time.monotonic()
         q = self.make_select().select(
-            Count(), Checksum(self._relevant_columns_repr), optimizer_hints=self.optimizer_hints
+            Count(), Checksum(self._relevant_columns_repr('select_checksum')), optimizer_hints=self.optimizer_hints
         )
         count, checksum = self.database.query(q, tuple)
         duration = time.monotonic() - start
@@ -340,7 +381,7 @@ class TableSegment:
             .select(
                 Code(group_by_expr),
                 Count(), 
-                Checksum(self._relevant_columns_repr),
+                Checksum(self._relevant_columns_repr('select_checksum')),
                 **maybe_optimizer_hints)
             .order_by(Code(group_by_expr))
             .group_by(self.source_table[group_by_col])
@@ -384,8 +425,19 @@ class TableSegment:
     def query_key_range(self) -> Tuple[tuple, tuple]:
         """Query database for minimum and maximum key. This is used for setting the initial bounds."""
         # Normalizes the result (needed for UUIDs) after the min/max computation
+        logging.info(f'{self.database.name} query_key_range: {self.min_key} - {self.max_key}')
+
+        def normalize_range_select():
+            for k in self.key_columns:
+                converted_col, exclude_from = self.col_conversion(k)
+                for f in (min_, max_):
+                    if converted_col and 'key_range_select' not in exclude_from:
+                        yield ApplyFuncAndNormalizeAsString(Code(converted_col), f)
+                    else:
+                        yield ApplyFuncAndNormalizeAsString(this[k], f)
+
         select = self.make_select().select(
-            (ApplyFuncAndNormalizeAsString(this[k], f) for k in self.key_columns for f in (min_, max_)),
+            normalize_range_select(),
             optimizer_hints=self.optimizer_hints
         )
         result = tuple(self.database.query(select, tuple))

--- a/data_diff/thread_utils.py
+++ b/data_diff/thread_utils.py
@@ -82,3 +82,6 @@ class ThreadedYielder(Iterable):
                 self._futures.popleft()
             else:
                 sleep(0.001)
+
+    def abort(self) -> None:
+        self._pool.shutdown(wait=True, cancel_futures=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dsnparse = "*"
 click = "^8.1"
 rich = "*"
 toml = "^0.10.2"
-sqeleton = {git = "git@github.com:RoderickJDunn/sqeleton.git", rev = "fa23f08cb10437fee298f9a9f3b446f2e87528a5"}
+sqeleton = {git = "git@github.com:wealthsimple/sqeleton.git", rev = "aa1a60d58b2cc01be04123959fe7d1e46cb701fd"}
 mysql-connector-python = {version="8.0.29", optional=true}
 psycopg2 = {version="*", optional=true}
 snowflake-connector-python = {version="^2.7.2", optional=true}


### PR DESCRIPTION
### Summary
- Support overriding column types
- Added Grouping Hash algorithm to support single-pass hashing on large Oracle tables. 
- Disabled tracking
- Support sorting of results when single column of composite PK is used to find hashing ranges
- Support early abort (allows us to exit if timeout or result limit is reached)
- **Support custom column conversions**

## Supporting custom column conversions
Today data-diff always preprocesses columns in the same way for a given data type. This allows for normalization of columns between databases, so that hash comparisons are valid. 

However, there are some cases where we need to specify custom processing of a column in order to create a hash that can be compared to that of the other database. For example the `xxbrk_daily_price` Oracle table contains several columns of type `number` with no precision or scale specified. Fivetran may choose to replicate such columns to Redshift as strings. Today, for this case data-diff will fail right away due to a column type mismatch (it can't compare numerics with strings).

### Why simple casting doesn't work
- I tried to overcome the above issue by supporting column type overrides, but this feature is inadequate in this case. 
- The Oracle columns contain values with very wide range of scales - eg. values of both `1` and `99.01234567890123456789012345678901234567` are possible (that's a scale of 38).
- Those values also exist in Redshift, but they are strings
- If I treat both columns as numeric(38,10), most comparisons pass, but many fail due to minute differences caused by rounding. In Oracle, casting to number(38,10) will yield a rounded number, but in Redshift casting the string to numeric(38,10) will truncate the number.
- If I treat both columns as strings, this similarly fails because Oracle implicitly rounds values before casting to varchar.  

### Solution
- Custom processing of columns allows us to TRUNCATE the oracle values, and thus prevent the implicit rounding from occurring. In summary:
  - Oracle columns are TRUNCATED to a scale of 10, then converted to a string with a normalized format
  - Redshift columns are cast to numeric(38,10), then converted to a string with the same normalized format