### PR TITLE
TimestampGroupingHashDiffer, and tweaks for replication validation

### DIFF
--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -84,6 +84,9 @@ def diff_tables(
     hash_query_type: str = None,
     # Optimizer hints for Select queries
     optimizer_hints: Optional[str] = None,
+
+    # 8-hour timeout by default
+    timeout: int = 8*60*60
 ) -> tuple[TableDiffer, Iterator]:
     """Finds the diff between table1 and table2.
 
@@ -168,6 +171,7 @@ def diff_tables(
                 bisection_threshold=bisection_threshold,
                 threaded=threaded,
                 max_threadpool_size=max_threadpool_size,
+                timeout=timeout
             )
         else:
             logging.info('Diffing with HASHDIFF grouped query')
@@ -176,6 +180,7 @@ def diff_tables(
                 bisection_threshold=bisection_threshold,
                 threaded=threaded,
                 max_threadpool_size=max_threadpool_size,
+                timeout=timeout
             )         
     elif algorithm == Algorithm.JOINDIFF:
         if isinstance(materialize_to_table, str):
@@ -188,6 +193,7 @@ def diff_tables(
             materialize_to_table=materialize_to_table,
             materialize_all_rows=materialize_all_rows,
             table_write_limit=table_write_limit,
+            timeout=timeout
         )
     else:
         raise ValueError(f"Unknown algorithm: {algorithm}")

--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -6,7 +6,7 @@ from sqeleton.abcs import DbTime, DbPath
 from .tracking import disable_tracking
 from .databases import connect
 from .diff_tables import Algorithm, TableDiffer
-from .hashdiff_tables import HashDiffer, DEFAULT_BISECTION_THRESHOLD, DEFAULT_BISECTION_FACTOR, GroupingHashDiffer
+from .hashdiff_tables import HashDiffer, DEFAULT_BISECTION_THRESHOLD, DEFAULT_BISECTION_FACTOR, GroupingHashDiffer, TsGroupingHashDiffer
 from .joindiff_tables import JoinDiffer, TABLE_WRITE_LIMIT
 from .table_segment import TableSegment
 from .utils import eval_name_template, Vector
@@ -167,6 +167,15 @@ def diff_tables(
             logging.info('Diffing with HASHDIFF multi-query')
 
             differ = HashDiffer(
+                bisection_factor=bisection_factor,
+                bisection_threshold=bisection_threshold,
+                threaded=threaded,
+                max_threadpool_size=max_threadpool_size,
+                timeout=timeout
+            )
+        elif segments[0].hash_query_type == 'ts_grouped' and segments[1].hash_query_type == 'ts_grouped':
+            logging.info('Diffing with HASHDIFF ts_grouped query')
+            differ = TsGroupingHashDiffer(
                 bisection_factor=bisection_factor,
                 bisection_threshold=bisection_threshold,
                 threaded=threaded,

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -386,6 +386,7 @@ class TableDiffer(ThreadBase, ABC):
         info_tree: InfoTree,
         level=0,
         max_rows=None,
+        seg_path=''
     ):
         assert table1.is_bounded and table2.is_bounded
 
@@ -402,6 +403,12 @@ class TableDiffer(ThreadBase, ABC):
         # Recursively compare each pair of corresponding segments between table1 and table2
         for i, (t1, t2) in enumerate(safezip(segmented1, segmented2)):
             info_node = info_tree.add_node(t1, t2, max_rows=max_rows)
+
+            if level == 0:
+                segment_path = f'{i+1}'
+            else:
+                segment_path = f'{seg_path}.{i+1}'
+
             ti.submit(
-                self._diff_segments, ti, t1, t2, info_node, max_rows, level + 1, i + 1, len(segmented1), priority=level
+                self._diff_segments, ti, t1, t2, info_node, max_rows, level + 1, i + 1, len(segmented1), priority=level, seg_path=segment_path
             )

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from functools import partial
 import os
 from numbers import Number
@@ -9,6 +10,7 @@ from operator import attrgetter, methodcaller
 from runtype import dataclass
 
 from sqeleton.abcs import ColType_UUID, NumericType, PrecisionType, StringType, Boolean, IKey
+from sqeleton.databases import DbTime
 
 from .info_tree import InfoTree
 from .utils import safezip
@@ -227,8 +229,8 @@ class HashDiffer(TableDiffer):
             return
 
         logging.info(f'Mismatch checksum {table1.min_key} - {table2.max_key}\n'
-                     f'T1: cs={checksum1}, count={count1}\n'
-                     f'T2: cs={checksum2}, count={count2}')
+                     f' T1: cs={checksum1}, count={count1}\n'
+                     f' T2: cs={checksum2}, count={count2}')
 
         info_tree.info.is_diff = True
         return self._bisect_and_diff_segments(ti, table1, table2, info_tree, level=level, max_rows=max(count1, count2), seg_path=segment_path)
@@ -313,8 +315,8 @@ class GroupingHashDiffer(HashDiffer):
             return
 
         logging.info(f'Mismatch checksum {segment1.min_key} - {segment1.max_key}\n'
-                     f'T1: cs={checksum1}, count={count1}\n'
-                     f'T2: cs={checksum2}, count={count2}')
+                     f' T1: cs={checksum1}, count={count1}\n'
+                     f' T2: cs={checksum2}, count={count2}')
 
         info_tree.info.is_diff = True
         return self._bisect_and_diff_segments(ti, segment1, segment2, info_tree, level=level, max_rows=max(count1, count2), seg_path=seg_path)
@@ -377,7 +379,7 @@ class GroupingHashDiffer(HashDiffer):
         logger.info(f'checkpoints: {checkpoints}')
 
         if table1.hash_query_type == 'multi' and table2.hash_query_type == 'multi':
-            raise ValueError('At least 1 table must use the groupby hash query type')
+            raise ValueError('At least 1 table must use the "grouped" hash query type')
 
         segmented1 = table1.segment_by_checkpoints(checkpoints)
         segmented2 = table2.segment_by_checkpoints(checkpoints)
@@ -433,8 +435,8 @@ class GroupingHashDiffer(HashDiffer):
             table1_res = all_results[0]
             table2_res = all_results[1:] if table2.hash_query_type == 'multi' else all_results[1]
 
-        print_res('table1_res', table1_res)
-        print_res('table2_res', table2_res)
+        # print_res('table1_res', table1_res)
+        # print_res('table2_res', table2_res)
 
         # compare results for each segment in parallel
         for idx, (res1, res2, seg1, seg2) in enumerate(zip(table1_res, table2_res, segmented1, segmented2)):

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -203,6 +203,9 @@ class TableSegment:
 
     def get_schema(self):
         return self.database.query_table_schema(self.table_path)
+    
+    def set_query_timeout(self, timeout: int) -> None:
+        self.database.set_query_timeout(timeout)
 
     def _make_key_range(self):
         if self.min_key is not None:

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -16,7 +16,7 @@ from sqeleton.queries.extras import ApplyFuncAndNormalizeAsString, NormalizeAsSt
 from sqeleton.abcs import database_types as DB_TYPES
 
 
-LOG_FORMAT = "[%(asctime)s] %(levelname)s - [%(db)s] %(message)s"
+LOG_FORMAT = "[%(db)s] %(message)s"
 DATE_FORMAT = "%H:%M:%S"
 FORMATTER = logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dsnparse = "*"
 click = "^8.1"
 rich = "*"
 toml = "^0.10.2"
-sqeleton = {git = "git@github.com:wealthsimple/sqeleton.git", rev = "aa1a60d58b2cc01be04123959fe7d1e46cb701fd"}
+sqeleton = {git = "git@github.com:wealthsimple/sqeleton.git", rev = "b38c1beef0284decbd7a84555eb2861ea5fde5e5"}
 mysql-connector-python = {version="8.0.29", optional=true}
 psycopg2 = {version="*", optional=true}
 snowflake-connector-python = {version="^2.7.2", optional=true}


### PR DESCRIPTION
- Support for timing out at the query level by setting DB parameter (only supported in Postgres so far)
- When we DL rows in a segment (count < bisection_threshold) don't include the upper bound on update_column, then discard any row-pairs in the diff that are outside the update range. This allows us to eliminate a fair number of false positives during replication validation
- TsGroupingHashDiffer
  - Modified version of the hash differ that groups by a timestamp column instead of segmenting by primary key ranges
  - It executes a single GROUP BY query for each parent segment, instead of dividing the parent segment into children and running checksums on each one individually. This can be much faster depending on the table
  - Also allows us to narrow down discrepancies to small regions without a PK.
- Improved logs for better following of overall diff path, and pruned excess