### PR TITLE
Oracle performance and various fixes

### DIFF
--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -703,12 +703,12 @@ class TsGroupingHashDiffer(GroupingHashDiffer):
         # create TableSegments from each result row
         if len(table1_res) >= 1:
             segmented1 = [table1.new(group_min=str_to_dt(r[0]), 
-                                     group_max=str_to_dt(table1_res[idx+1][0])) for idx, r in enumerate(table1_res[:-1])]   
+                                     group_max=str_to_dt(add_group_grain(r[0], table1))) for r in table1_res[:-1]]   
             group_max1 = table1.group_max or add_group_grain(str_to_dt(table1_res[-1][0]), table1)
             segmented1.append(table1.new(group_min=str_to_dt(table1_res[-1][0]), group_max=group_max1))
 
             segmented2 = [table2.new(group_min=str_to_dt(r[0]), 
-                                     group_max=str_to_dt(table2_res[idx+1][0])) for idx, r in enumerate(table2_res[:-1])]
+                                     group_max=str_to_dt(add_group_grain(r[0], table2))) for r in table2_res[:-1]]
             group_max2 = table2.group_max or add_group_grain(str_to_dt(table2_res[-1][0]), table2)
             segmented2.append(table2.new(group_min=str_to_dt(table2_res[-1][0]), group_max=group_max2))
 

--- a/data_diff/sqeleton/databases/oracle.py
+++ b/data_diff/sqeleton/databases/oracle.py
@@ -69,7 +69,7 @@ class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
         return f"to_char({value}, '{format_str}')"
 
     def normalize_string(self, value: str, coltype: StringType) -> str:
-        # why did we have to add this? Makes varchar cols with emojis compat with redshift
+        # why did we have to add this? Makes varchar cols with emojis compat with redshift. Hmm but apparently not in all cases.
         return f"cast(CONVERT({value}, 'AL32UTF8') as varchar(1024))"
 
 class Mixin_Schema(AbstractMixin_Schema):

--- a/data_diff/sqeleton/databases/oracle.py
+++ b/data_diff/sqeleton/databases/oracle.py
@@ -119,7 +119,7 @@ class Dialect(BaseDialect, Mixin_Schema, Mixin_OptimizerHints):
         return f"({joined_exprs})"
 
     def timestamp_value(self, t: DbTime) -> str:
-        return "timestamp '%s'" % t.isoformat(" ")
+        return "TO_DATE('%s', 'YYYY-MM-DD HH24:MI:SS')" % t.isoformat(" ")
 
     def random(self) -> str:
         return "dbms_random.value"

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -367,7 +367,13 @@ class TableSegment:
         # - extra columns
         key_cols = self.true_key_columns or list(self.key_columns)
         group_col_offset = 1 if self.group_by_column else 0
-        return len(key_cols) + group_col_offset
+
+        if self.case_insensitive_idx(key_cols, self.update_column) != -1:
+            return self.case_insensitive_idx(key_cols, self.update_column)
+        elif self.group_by_column == self.update_column:
+            return len(key_cols)
+        else:
+            return len(key_cols) + group_col_offset
     
     def col_conversion(self, c: str) -> tuple[Optional[str], Optional[list]]:
         c_type = self._schema[c].__class__.__name__


### PR DESCRIPTION
- Use `TO_DATE` as default timestamp conversion in Oracle. Its much faster than `timestamp` or `TO_TIMESTAMP`.
- Fix edge case where update_col_idx returns wrong index when update_col is also a key_column
- Fix group_max calculation to increment group_min by 1 unit of the current time-grain. Previously we were using the group_min of the next group, which resulted in a range that was too large whenever there were missing groups. Missing groups are common as time-grains become smaller (eg. minutes)