### PR TITLE
Various Improvements (0.8.46)

### DIFF
--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -186,6 +186,23 @@ def diff_tables(
                 max_threadpool_size=max_threadpool_size,
                 timeout=timeout
             )
+        elif segments[0].hash_query_type == 'ts_grouped_preempt' and segments[1].hash_query_type == 'ts_grouped_preempt':
+            logging.info('Diffing with HASHDIFF ts_grouped_preempt query')
+
+            # make sure update_columns is not None for both tables
+            assert segments[0].update_column is not None and segments[1].update_column is not None, "update_column is required for ts_grouped_preempt query"
+
+            # make sure max_update is not None for both tables
+            assert segments[0].max_update is not None and segments[1].max_update is not None, "max_update is required for ts_grouped_preempt query"
+
+            differ = TsGroupingHashDiffer(
+                bisection_factor=bisection_factor,
+                bisection_threshold=bisection_threshold,
+                threaded=threaded,
+                max_threadpool_size=max_threadpool_size,
+                timeout=timeout,
+                update_handling='preemptive'
+            )
         else:
             logging.info('Diffing with HASHDIFF grouped query')
             differ = GroupingHashDiffer(

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -676,8 +676,9 @@ class TsGroupingHashDiffer(GroupingHashDiffer):
             if r1[2] != r2[2]:
                 summary[r1[0]].append(f'ChSum mismatch: {r1[2]} != {r2[2]}')
         if len(summary):
-            summary_str = '\n'.join([f' - {k}: {", ".join(v)}' for k, v in summary.items()])
-            logging.info(f'Groups with discrepancies: {len(summary)}\n{summary_str}')
+            summary_str = '\n'.join([f' - {k}: {", ".join(v)}' for k, v in list(summary.items())[:5000]])
+            limit_warning = ' (Showing last 5000)' if len(summary) > 5000 else ''
+            logging.info(f'Groups with discrepancies: {len(summary)}{limit_warning}\n{summary_str}')
 
         def str_to_dt(dt) -> DbTime:
             if dt is None:

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -4,7 +4,7 @@ import os
 from numbers import Number
 import logging
 from collections import defaultdict
-from typing import Any, Callable, Iterator, List, Tuple
+from typing import Any, Callable, Iterator, List, Optional, Tuple
 from operator import attrgetter, methodcaller
 
 from runtype import dataclass
@@ -539,6 +539,28 @@ class GroupingHashDiffer(HashDiffer):
 class TsGroupingHashDiffer(GroupingHashDiffer):
 
     stats: dict = {}
+    update_handling: Optional[str] = 'simultaneous'
+
+    def count_checksum_with_preemtive_updates(self, table1: TableSegment, table2: TableSegment, level: int):
+        t1_results = table1.count_and_checksum_by_ts_group_with_recent_updates(level)
+        logging.debug(f't1 results (len={len(t1_results)})\n' +
+                     '\n'.join([str(r) for r in t1_results[:10]]) + '\n...\n' + 
+                     '\n'.join([str(r) for r in t1_results[-10:]]))
+
+        # # get keys of recent updates in t1
+        recently_updated = [id_val for row in t1_results for id_val in row[3]]
+
+        logging.info(f'Excluding {len(recently_updated)} recently updated ids from destination query')
+
+        t2_results = table2.count_and_checksum_by_ts_group(level, exclude_ids=recently_updated)
+        logging.debug(f't2 results (len={len(t2_results)})\n' +
+                     '\n'.join([str(r) for r in t2_results[:10]]) + '\n...\n' + 
+                     '\n'.join([str(r) for r in t2_results[-10:]]))
+        
+        # remove last item from all rows of t1_results. Don't need the ids anymore
+        t1_results = [r[:-1] for r in t1_results]
+        
+        return t1_results, t2_results
 
     def _diff_segments(
         self,
@@ -566,7 +588,7 @@ class TsGroupingHashDiffer(GroupingHashDiffer):
                 segment1.min_key,
                 segment1.max_key,
             )
-            assert checksum1 is None and checksum2 is None
+            assert (checksum1 is None or checksum1 == 0) and (checksum2 is None or checksum2 == 0)
             info_tree.info.is_diff = False
             return
 
@@ -627,7 +649,6 @@ class TsGroupingHashDiffer(GroupingHashDiffer):
             out = [str(r) for r in res]
             logger.info('{}\n{}'.format(label, "\n".join(out)))
 
-        query_fns = []
         seg_path_str = seg_path or "root"
         group_range = f'{table1.group_min}..{table1.group_max}' if table1.group_min or table1.group_max else 'Full Range'
         row_count = max_rows or '?'
@@ -636,14 +657,14 @@ class TsGroupingHashDiffer(GroupingHashDiffer):
             f"group-range: {group_range}, "
             f"size = {row_count}"
         )
-        query_fns.append(partial(table1.count_and_checksum_by_ts_group, level=level))
-        query_fns.append(partial(table2.count_and_checksum_by_ts_group, level=level))
-
 
         self.set_query_timeouts([table1, table2])
 
         # submit grouping queries to DB threadpools
-        all_results = self._threaded_call('count_and_checksum_by_ts_group', [table1, table2], level=level)
+        if self.update_handling == 'preemptive':
+            all_results = self.count_checksum_with_preemtive_updates(table1, table2, level)
+        else:
+            all_results = self._threaded_call('count_and_checksum_by_ts_group', [table1, table2], level=level)
 
         table1_res = all_results[0]
         table2_res = all_results[1]

--- a/data_diff/sqeleton/queries/ast_classes.py
+++ b/data_diff/sqeleton/queries/ast_classes.py
@@ -33,6 +33,12 @@ class ExprNode(Compilable):
             if k == "source_table":
                 # Skip data-sources, we're only interested in data-parameters
                 continue
+            if isinstance(vs, dict):
+                # @rjd: this is vital in order for columns only referenced within Code() blocks to be resolved at compile time
+                for v in vs.values():
+                    if isinstance(v, ExprNode):
+                        yield from v._dfs_values()
+                continue
             if not isinstance(vs, (list, tuple)):
                 vs = [vs]
             for v in vs:

--- a/data_diff/sqeleton/queries/ast_classes.py
+++ b/data_diff/sqeleton/queries/ast_classes.py
@@ -871,6 +871,17 @@ class In(ExprNode):
     def compile(self, c: Compiler):
         elems = ", ".join(map(c.compile, self.list))
         return f"({c.compile(self.expr)} IN ({elems}))"
+    
+@dataclass
+class NotIn(ExprNode):
+    expr: Expr
+    list: Sequence[Expr]
+
+    type = bool
+
+    def compile(self, c: Compiler):
+        elems = ", ".join(map(c.compile, self.list))
+        return f"({c.compile(self.expr)} NOT IN ({elems}))"
 
 
 @dataclass

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -332,7 +332,7 @@ class TableSegment:
             update_col_idx_in_extras = self.case_insensitive_idx(extras, self.update_column)
 
             if update_col_idx_in_extras >= 0:
-                # remove from curr location (we'll end up with it in correct position in extras (front))
+                # remove from curr location (we'll end up with it in correct position in extras (front, but after group_by if exists))
                 extras.pop(update_col_idx_in_extras)
 
             if update_col_idx_in_keys == -1:
@@ -352,6 +352,12 @@ class TableSegment:
                 # as long as its not already in key columns, add to front of extras
                 extras = [self.group_by_column] + extras
 
+        if extras:
+            # make sure no key columns are also present in extras
+            for key_col in key_cols:
+                key_col_idx_in_extras = self.case_insensitive_idx(extras, key_col)
+                if key_col_idx_in_extras >= 0:
+                    extras.pop(key_col_idx_in_extras)
 
         return list(key_cols) + extras
     

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -7,6 +7,8 @@ from itertools import product
 
 from runtype import dataclass
 
+from data_diff.sqeleton.queries.ast_classes import NotIn
+
 from .utils import safezip, Vector, split_space
 from data_diff.sqeleton.utils import ArithString
 from data_diff.sqeleton.databases import Database, DbPath, DbKey, DbTime
@@ -14,6 +16,7 @@ from data_diff.sqeleton.schema import Schema, create_schema
 from data_diff.sqeleton.queries import Count, Checksum, SKIP, table, this, Expr, min_, max_, Code, Compiler
 from data_diff.sqeleton.queries.extras import ApplyFuncAndNormalizeAsString, NormalizeAsString
 from data_diff.sqeleton.abcs import database_types as DB_TYPES
+from data_diff.sqeleton import code
 
 
 LOG_FORMAT = "[%(db)s] %(message)s"
@@ -114,6 +117,37 @@ def create_mesh_from_points(*values_per_dim: list) -> List[Tuple[Vector, Vector]
     expected_len = int_product(len(v) - 1 for v in values_per_dim)
     assert len(res) == expected_len, (len(res), expected_len)
     return res
+
+
+GRAINS = {
+    'year': {
+        'ora': "TRUNC({group_by_col}, 'Y')"
+    },
+    'month': {
+        'ora': "TRUNC({group_by_col}, 'MM')"
+    },
+    'day': {
+        'ora': "TRUNC({group_by_col}, 'DD')"
+    },
+    'hour': {
+        'ora': "TRUNC({group_by_col}, 'HH')"
+    },
+    'minute': {
+        'ora': "TRUNC({group_by_col}, 'MI')"
+    },
+    'second': {
+        'ora': "cast({group_by_col} as date)"
+    }
+    # 'half_second': {
+    #     'ora': "TRUNC({group_by_col}, )"
+    # }
+    # 'tenth_second': {
+    #     'ora': "TRUNC({group_by_col}, )"
+    # }
+    # 'millisecond':  {
+    #     'ora': "TRUNC({group_by_col}, )"
+    # }
+}
 
 
 @dataclass
@@ -257,12 +291,17 @@ class TableSegment:
         return table(*self.table_path, schema=self._schema)
 
     def make_select(self, use_min_update = True, use_max_update = True,
-                    use_group_min = True, use_group_max = True):
+                    use_group_min = True, use_group_max = True,
+                    exclude_ids = None):
+        if exclude_ids:
+            assert len(self.key_columns) == 1, 'Exclusion of IDs only supported for single-column PKs'
+
         return self.source_table.where(
             *self._make_key_range(), 
             *self._make_update_range(include_min=use_min_update, include_max=use_max_update), 
             *self._make_groupby_range(include_min=use_group_min, include_max=use_group_max), 
-            Code(self._where()) if self.where else SKIP
+            Code(self._where()) if self.where else SKIP,
+            NotIn(self.key_cols_repr, exclude_ids) if exclude_ids else SKIP
         )
 
     def get_values(self) -> list:
@@ -416,6 +455,13 @@ class TableSegment:
         return normalized_cols
     
     @property
+    def key_cols_repr(self) -> List[Expr]:
+        if len(self.key_columns) == 1:
+            return this[self.key_columns[0]]
+        else:
+            return Code(f'({",".join([c for c in self.key_columns])})')
+    
+    @property
     def key_indices(self) -> Tuple[str]:
         key_cols = self.true_key_columns or self.key_columns
         return [self.relevant_columns.index(c.lower()) for c in key_cols]
@@ -513,53 +559,78 @@ class TableSegment:
 
         return rows
     
-    def count_and_checksum_by_ts_group(self, level: int) -> Tuple[Tuple[int, int]]:
-        GRAINS = {
-            'year': {
-                'ora': "TRUNC({group_by_col}, 'Y')"
-            },
-            'month': {
-                'ora': "TRUNC({group_by_col}, 'MM')"
-            },
-            'day': {
-                'ora': "TRUNC({group_by_col}, 'DD')"
-            },
-            'hour': {
-                'ora': "TRUNC({group_by_col}, 'HH')"
-            },
-            'minute': {
-                'ora': "TRUNC({group_by_col}, 'MI')"
-            },
-            'second': {
-                'ora': "cast({group_by_col} as date)"
-            }
-            # 'half_second': {
-            #     'ora': "TRUNC({group_by_col}, )"
-            # }
-            # 'tenth_second': {
-            #     'ora': "TRUNC({group_by_col}, )"
-            # }
-            # 'millisecond':  {
-            #     'ora': "TRUNC({group_by_col}, )"
-            # }
-        }
-
-
-        group_by_col = self.group_by_column
+    def get_group_by_expr(self, level: int) -> str:
         curr_grain = self.group_grains[level]
-
-        # temp hack (should utilize sqeleton)
+        # temp hack (should utilize sqeleton)   
         if self.database.name in ['Redshift', 'PostgreSQL']:
-            group_by_expr = f"DATE_TRUNC('{curr_grain}', {group_by_col})"
+            group_by_expr = f"DATE_TRUNC('{curr_grain}', {self.group_by_column})"
         elif self.database.name == 'Oracle':
-            group_by_expr = GRAINS[curr_grain]['ora'].format(group_by_col=group_by_col)
+            group_by_expr = GRAINS[curr_grain]['ora'].format(group_by_col=self.group_by_column)
         else:
             raise NotImplementedError(f'Unsupported database for checksum by TS group: {self.database.name}')
+
+        return group_by_expr
+
+    def count_and_checksum_by_ts_group_with_recent_updates(self, level: int) -> Tuple[Tuple[int, int]]:
+
+        # NOTE: the below query actually works with composite PKs. However, I can't find a portable
+        #       way to pass the composite ID's to the next query as the `exclude_ids` parameter.
+        #       Sqeleton doesn't seem able to handle syntax like `WHERE (id1, id2) NOT IN ((1, 2), (3, 4))`
+        #       and hardcoding the formatting will get messy, and difficult (eg. different key data types)
+        assert len(self.key_columns) == 1, 'Exclusion of IDs only supported for single-column PKs'
+        assert self.database.name in ['Redshift', 'PostgreSQL'], 'Unsupported database for preemtive ts_group checkusm'
+
+        group_by_col = self.group_by_column
+        group_by_expr = self.get_group_by_expr(level)
 
         maybe_optimizer_hints = \
             {'optimizer_hints': self.optimizer_hints} if level < self.opt_hints_depth else {}
 
-        q = (self.make_select(use_max_update=True)
+        q = (self.make_select(use_max_update=False)
+            .select(
+                Code(group_by_expr),
+                code("{count} filter (where {update_cond})",
+                     count=Count(),
+                     update_cond=this[self.update_column] < self.max_update),
+                code("{checksum} filter (where {update_cond})",
+                     checksum=Checksum(self._relevant_columns_repr('select_checksum')),
+                     update_cond=this[self.update_column] < self.max_update),
+                code("array_remove(array_agg(CASE WHEN {update_cond} THEN {key_columns} END), NULL)", 
+                     update_cond=this[self.update_column] >= self.max_update,
+                     key_columns=self.key_cols_repr),
+                **maybe_optimizer_hints)
+            .order_by(Code(group_by_expr))
+            .group_by(self.source_table[group_by_col])
+            .agg(self.source_table[group_by_col])
+            .table
+            .replace(group_by_exprs=[Code(group_by_expr)]))
+        
+        start = time.monotonic()
+        rows = self.database.query(q, list)
+        duration = time.monotonic() - start
+
+        self.logger.info('Checksum_by_ts_group_preemtive query took %s seconds', duration)
+
+        # this query can result in null/None checksum & count, so set those instances to 0 manually
+        for idx, r in enumerate(rows):
+            r = list(r)
+            if r[1] is None:
+                r[1] = 0
+                rows[idx] = tuple(r)
+            if r[2] is None:
+                r[2] = 0
+                rows[idx] = tuple(r)
+
+        return rows
+    
+    def count_and_checksum_by_ts_group(self, level: int, exclude_ids = None) -> Tuple[Tuple[int, int]]:
+        group_by_col = self.group_by_column
+        group_by_expr = self.get_group_by_expr(level)
+        
+        maybe_optimizer_hints = \
+            {'optimizer_hints': self.optimizer_hints} if level < self.opt_hints_depth else {}
+        
+        q = (self.make_select(use_max_update=True, exclude_ids=exclude_ids)
             .select(
                 Code(group_by_expr),
                 Count(), 

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -362,6 +362,12 @@ class TableSegment:
         return list(key_cols) + extras
     
     @property
+    def group_by_and_update_are_same_col(self) -> bool:
+        if isinstance(self.group_by_column, str) and isinstance(self.update_column, str):
+            return self.group_by_column.lower() == self.update_column.lower()
+        return False
+
+    @property
     def update_col_idx(self) -> int:
         if not self.update_column:
             raise ValueError(f'No update_column specified for table {self.table_path}')
@@ -376,7 +382,7 @@ class TableSegment:
 
         if self.case_insensitive_idx(key_cols, self.update_column) != -1:
             return self.case_insensitive_idx(key_cols, self.update_column)
-        elif self.group_by_column == self.update_column:
+        elif self.group_by_and_update_are_same_col:
             return len(key_cols)
         else:
             return len(key_cols) + group_col_offset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-diff"
-version = "0.8.45"
+version = "0.8.46"
 description = "Command-line tool and Python library to efficiently diff rows across two different databases."
 authors = ["Datafold <data-diff@datafold.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ presto-python-client = {version="*", optional=true}
 clickhouse-driver = {version="*", optional=true}
 duckdb = {version="*", optional=true}
 dbt-artifacts-parser = {version="^0.4.2"}
-dbt-core = {version="^1.0.0"}
 keyring = "*"
 tabulate = "^0.9.0"
 preql = {version="^0.2.19", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-diff"
-version = "0.8.4"
+version = "0.8.45"
 description = "Command-line tool and Python library to efficiently diff rows across two different databases."
 authors = ["Datafold <data-diff@datafold.com>"]
 license = "MIT"


### PR DESCRIPTION
- preemtive ts_group algorithm for Postgres-Redshift validation. T1 grouping hash query also returns ids of recently updated rows (per group). Those recently updated ids are passed to the T2 query for exclusion from checksums.
- limit logging to reduce chances of webserver oom
- relevant_columns fix edge case where key column can be duplicated
- update_col_idx fix edge case when group_by and update cols are the same.

Bump to version `0.8.46`